### PR TITLE
[time] Emit timeChanged when the display state changes

### DIFF
--- a/src/nemowallclock_meego.cpp
+++ b/src/nemowallclock_meego.cpp
@@ -88,8 +88,10 @@ WallClockPrivateMeego::~WallClockPrivateMeego()
 
 void WallClockPrivateMeego::onDisplayStatusChanged(const QString &status)
 {
-    if (status == MCE_DISPLAY_ON_STRING)
+    if (status == MCE_DISPLAY_ON_STRING) {
         update();
+        timeChanged();
+    }
 }
 
 QString WallClockPrivateMeego::timezone() const


### PR DESCRIPTION
update() will trigger the timer update, but won't actually fire timeChanged,
which means that time updates still won't come in as needed.

Adapted from a patch of @rburchell's. This doesn't entirely solve the problems: there is still a flicker of the wrong time before the update.
