### PR TITLE
Remove WallClock::updateTimer() slot declaration

### DIFF
--- a/src/nemowallclock.h
+++ b/src/nemowallclock.h
@@ -65,9 +65,6 @@ public:
     UpdateFrequency updateFrequency() const;
     void setUpdateFrequency(UpdateFrequency);
 
-private slots:
-    void updateTimer();
-
 signals:
     void enabledChanged();
     void timeChanged();


### PR DESCRIPTION
There's no implementation.
