### PR TITLE
[nemo-qml-plugin-time] Update JS engine timezone on changes

### DIFF
--- a/src/nemowallclock_meego.cpp
+++ b/src/nemowallclock_meego.cpp
@@ -31,6 +31,8 @@
  */
 
 #include <QtDBus/QDBusReply>
+#include <QQmlEngine>
+#include <qqml.h>
 #include <functional>
 #include <timed-qt5/interface>
 #include <timed-qt5/wallclock>
@@ -154,13 +156,21 @@ void WallClockPrivateMeego::settingsChanged(const Maemo::Timed::WallClock::Info 
 
     info = newInfo;
 
+    if (tzChange || tzaChange) {
+        QQmlEngine *engine = QtQml::qmlEngine(wallClock());
+        // Notify qml engine timezone before emitting signals, so handler code has it already up to date
+        if (engine) {
+            engine->evaluate("Date.timeZoneUpdated()");
+        }
+    }
+
     if (tzChange)
         timezoneChanged();
     if (tzaChange)
         timezoneAbbreviationChanged();
     if (time_changed)
         systemTimeChanged();
-    if (tzaChange || tzaChange || time_changed || hourModeChange)
+    if (tzChange || tzaChange || time_changed || hourModeChange)
         timeChanged();
 }
 

--- a/src/nemowallclock_p.h
+++ b/src/nemowallclock_p.h
@@ -62,6 +62,7 @@ protected:
     void timezoneAbbreviationChanged();
     void timeChanged();
     void systemTimeChanged();
+    WallClock *wallClock() { return q; }
 
 private:
     virtual void updateCurrentTime(int);


### PR DESCRIPTION
The Qml engine needs to be explicitly notified on timezone changes.
Added code for doing that in WallClock so qml code binding to time value
doesn't need to.
